### PR TITLE
Fix require.js path as changed in 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.6.1</upstream.version>
+        <upstream.version>2.6.2</upstream.version>
         <upstream.url>https://github.com/facebook/immutable-js</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
             {
                 "paths": {
-                    "Immutable"     : "Immutable",
-                    "Immutable.min" : "Immutable.min"
+                    "immutable"     : "immutable",
+                    "immutable-min" : "immutable.min"
                 }
             }
         </requirejs>


### PR DESCRIPTION
The dist file names are changed in 2.6.1 to fix facebook/immutable-js#153 but I missed it in the previous PR.
